### PR TITLE
Refine code block styling

### DIFF
--- a/_sass/_highlights.scss
+++ b/_sass/_highlights.scss
@@ -1,9 +1,11 @@
 
-.highlight {
-  background-color: #f8f8f8;
-  padding: 16px;
-  border: 1px solid #e1e4e8;
-  border-radius: 6px;
+.highlight,
+pre,
+pre code {
+  background: #f5f5f5;
+  border: 1px solid #e1e1e1;
+  border-radius: 4px;
+  padding: 12px 16px;
   margin: 16px 0;
   overflow-x: auto;
   font-size: 14px;
@@ -13,13 +15,14 @@
 code {
   font-family: 'SF Mono', Monaco, Inconsolata, 'Roboto Mono', Consolas, 'Courier New', monospace;
   font-size: 0.85em;
-  background-color: rgba(27,31,35,0.05);
+  background: rgba(27,31,35,0.05);
   padding: 2px 4px;
   border-radius: 3px;
 }
 
-.highlight code {
-  background-color: transparent;
+.highlight code,
+pre code {
+  background: none;
   padding: 0;
 }
 
@@ -48,18 +51,6 @@ code {
 .highlight .mf { color: #005cc5 } /* Literal.Number.Float */
 .highlight .mh { color: #005cc5 } /* Literal.Number.Hex */
 .highlight .mi { color: #005cc5 } /* Literal.Number.Integer */
-/* Minimal styling for triple-backtick code blocks */
-pre, pre code {
-  background-color: #f8f8f8;
-  padding: 16px;
-  border: 1px solid #e1e4e8;
-  border-radius: 6px;
-  margin: 16px 0;
-  font-size: 14px;
-  line-height: 1.45;
-  font-family: 'SF Mono', Monaco, Inconsolata, 'Roboto Mono', Consolas, 'Courier New', monospace;
-  overflow-x: auto;
-}
 .highlight .mo { color: #005cc5 } /* Literal.Number.Oct */
 .highlight .s2 { color: #032f62 } /* Literal.String.Double */
 .highlight .s1 { color: #032f62 } /* Literal.String.Single */


### PR DESCRIPTION
## Summary
- simplify `pre` and `.highlight` styling for consistent, minimal code blocks
- unify inline code appearance

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68add225d5088320924513bed8cd4172