### PR TITLE
feat: update code block theme

### DIFF
--- a/_sass/_highlights.scss
+++ b/_sass/_highlights.scss
@@ -1,9 +1,77 @@
+/* Dark theme code block styling (Dracula) kept for reference */
+// 
+// .highlight,
+// pre,
+// pre code {
+//   background: #282a36;
+//   color: #f8f8f2;
+//   border: none;
+//   border-radius: 4px;
+//   padding: 12px 16px;
+//   margin: 16px 0;
+//   overflow-x: auto;
+//   font-size: 14px;
+//   line-height: 1.45;
+// }
+// 
+// code {
+//   font-family: 'SF Mono', Monaco, Inconsolata, 'Roboto Mono', Consolas, 'Courier New', monospace;
+//   font-size: 0.85em;
+//   background: rgba(27,31,35,0.05);
+//   padding: 2px 4px;
+//   border-radius: 3px;
+// }
+// 
+// .highlight code,
+// pre code {
+//   background: none;
+//   padding: 0;
+// }
+// 
+// /* Dracula syntax highlighting */
+// .highlight .c { color: #6272a4 } /* Comment */
+// .highlight .err { color: #ff5555 } /* Error */
+// .highlight .k { color: #ff79c6 } /* Keyword */
+// .highlight .o { color: #ff79c6 } /* Operator */
+// .highlight .p { color: #f8f8f2 } /* Punctuation */
+// .highlight .cm { color: #6272a4 } /* Comment.Multiline */
+// .highlight .cp { color: #6272a4 } /* Comment.Preproc */
+// .highlight .c1 { color: #6272a4 } /* Comment.Single */
+// .highlight .cs { color: #6272a4 } /* Comment.Special */
+// .highlight .gd { color: #ff5555 } /* Generic.Deleted */
+// .highlight .gi { color: #50fa7b } /* Generic.Inserted */
+// .highlight .kc { color: #bd93f9 } /* Keyword.Constant */
+// .highlight .kd { color: #ff79c6 } /* Keyword.Declaration */
+// .highlight .kn { color: #ff79c6 } /* Keyword.Namespace */
+// .highlight .kp { color: #ff79c6 } /* Keyword.Pseudo */
+// .highlight .kr { color: #ff79c6 } /* Keyword.Reserved */
+// .highlight .kt { color: #8be9fd } /* Keyword.Type */
+// .highlight .m { color: #bd93f9 } /* Literal.Number */
+// .highlight .s { color: #f1fa8c } /* Literal.String */
+// .highlight .na { color: #8be9fd } /* Name.Attribute */
+// .highlight .nb { color: #50fa7b } /* Name.Builtin */
+// .highlight .nc { color: #8be9fd } /* Name.Class */
+// .highlight .nf { color: #50fa7b } /* Name.Function */
+// .highlight .nn { color: #f8f8f2 } /* Name.Namespace */
+// .highlight .nt { color: #ff79c6 } /* Name.Tag */
+// .highlight .nv { color: #8be9fd } /* Name.Variable */
+// .highlight .mf { color: #bd93f9 } /* Literal.Number.Float */
+// .highlight .mh { color: #bd93f9 } /* Literal.Number.Hex */
+// .highlight .mi { color: #bd93f9 } /* Literal.Number.Integer */
+// .highlight .mo { color: #bd93f9 } /* Literal.Number.Oct */
+// .highlight .sb { color: #f1fa8c } /* Literal.String.Backtick */
+// .highlight .sc { color: #f1fa8c } /* Literal.String.Char */
+// .highlight .sd { color: #f1fa8c } /* Literal.String.Doc */
+// .highlight .s1 { color: #f1fa8c } /* Literal.String.Single */
+// .highlight .s2 { color: #f1fa8c } /* Literal.String.Double */
+// .highlight .se { color: #f1fa8c } /* Literal.String.Escape */
 
+// Light theme code block styling
 .highlight,
 pre,
 pre code {
-  background: #282a36;
-  color: #f8f8f2;
+  background: #f6f8fa;
+  color: #24292e;
   border: none;
   border-radius: 4px;
   padding: 12px 16px;
@@ -27,40 +95,40 @@ pre code {
   padding: 0;
 }
 
-/* Dracula syntax highlighting */
-.highlight .c { color: #6272a4 } /* Comment */
-.highlight .err { color: #ff5555 } /* Error */
-.highlight .k { color: #ff79c6 } /* Keyword */
-.highlight .o { color: #ff79c6 } /* Operator */
-.highlight .p { color: #f8f8f2 } /* Punctuation */
-.highlight .cm { color: #6272a4 } /* Comment.Multiline */
-.highlight .cp { color: #6272a4 } /* Comment.Preproc */
-.highlight .c1 { color: #6272a4 } /* Comment.Single */
-.highlight .cs { color: #6272a4 } /* Comment.Special */
-.highlight .gd { color: #ff5555 } /* Generic.Deleted */
-.highlight .gi { color: #50fa7b } /* Generic.Inserted */
-.highlight .kc { color: #bd93f9 } /* Keyword.Constant */
-.highlight .kd { color: #ff79c6 } /* Keyword.Declaration */
-.highlight .kn { color: #ff79c6 } /* Keyword.Namespace */
-.highlight .kp { color: #ff79c6 } /* Keyword.Pseudo */
-.highlight .kr { color: #ff79c6 } /* Keyword.Reserved */
-.highlight .kt { color: #8be9fd } /* Keyword.Type */
-.highlight .m { color: #bd93f9 } /* Literal.Number */
-.highlight .s { color: #f1fa8c } /* Literal.String */
-.highlight .na { color: #8be9fd } /* Name.Attribute */
-.highlight .nb { color: #50fa7b } /* Name.Builtin */
-.highlight .nc { color: #8be9fd } /* Name.Class */
-.highlight .nf { color: #50fa7b } /* Name.Function */
-.highlight .nn { color: #f8f8f2 } /* Name.Namespace */
-.highlight .nt { color: #ff79c6 } /* Name.Tag */
-.highlight .nv { color: #8be9fd } /* Name.Variable */
-.highlight .mf { color: #bd93f9 } /* Literal.Number.Float */
-.highlight .mh { color: #bd93f9 } /* Literal.Number.Hex */
-.highlight .mi { color: #bd93f9 } /* Literal.Number.Integer */
-.highlight .mo { color: #bd93f9 } /* Literal.Number.Oct */
-.highlight .sb { color: #f1fa8c } /* Literal.String.Backtick */
-.highlight .sc { color: #f1fa8c } /* Literal.String.Char */
-.highlight .sd { color: #f1fa8c } /* Literal.String.Doc */
-.highlight .s1 { color: #f1fa8c } /* Literal.String.Single */
-.highlight .s2 { color: #f1fa8c } /* Literal.String.Double */
-.highlight .se { color: #f1fa8c } /* Literal.String.Escape */
+/* GitHub-like light syntax highlighting */
+.highlight .c { color: #6a737d } /* Comment */
+.highlight .err { color: #d73a49 } /* Error */
+.highlight .k { color: #d73a49 } /* Keyword */
+.highlight .o { color: #d73a49 } /* Operator */
+.highlight .p { color: #24292e } /* Punctuation */
+.highlight .cm { color: #6a737d } /* Comment.Multiline */
+.highlight .cp { color: #6a737d } /* Comment.Preproc */
+.highlight .c1 { color: #6a737d } /* Comment.Single */
+.highlight .cs { color: #6a737d } /* Comment.Special */
+.highlight .gd { color: #d73a49 } /* Generic.Deleted */
+.highlight .gi { color: #22863a } /* Generic.Inserted */
+.highlight .kc { color: #d73a49 } /* Keyword.Constant */
+.highlight .kd { color: #d73a49 } /* Keyword.Declaration */
+.highlight .kn { color: #d73a49 } /* Keyword.Namespace */
+.highlight .kp { color: #d73a49 } /* Keyword.Pseudo */
+.highlight .kr { color: #d73a49 } /* Keyword.Reserved */
+.highlight .kt { color: #6f42c1 } /* Keyword.Type */
+.highlight .m { color: #005cc5 } /* Literal.Number */
+.highlight .s { color: #032f62 } /* Literal.String */
+.highlight .na { color: #6f42c1 } /* Name.Attribute */
+.highlight .nb { color: #005cc5 } /* Name.Builtin */
+.highlight .nc { color: #6f42c1 } /* Name.Class */
+.highlight .nf { color: #6f42c1 } /* Name.Function */
+.highlight .nn { color: #24292e } /* Name.Namespace */
+.highlight .nt { color: #22863a } /* Name.Tag */
+.highlight .nv { color: #e36209 } /* Name.Variable */
+.highlight .mf { color: #005cc5 } /* Literal.Number.Float */
+.highlight .mh { color: #005cc5 } /* Literal.Number.Hex */
+.highlight .mi { color: #005cc5 } /* Literal.Number.Integer */
+.highlight .mo { color: #005cc5 } /* Literal.Number.Oct */
+.highlight .sb { color: #032f62 } /* Literal.String.Backtick */
+.highlight .sc { color: #032f62 } /* Literal.String.Char */
+.highlight .sd { color: #032f62 } /* Literal.String.Doc */
+.highlight .s1 { color: #032f62 } /* Literal.String.Single */
+.highlight .s2 { color: #032f62 } /* Literal.String.Double */
+.highlight .se { color: #032f62 } /* Literal.String.Escape */


### PR DESCRIPTION
## Summary
- keep Dracula dark code block styles commented for easy reversion
- add new light-themed code block styling with subtle gray background and GitHub-like colors

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68ae0b85ba408320b2d210bdf1afcd02