### PR TITLE
Enable MathJax on blog for LaTeX support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -67,6 +67,7 @@ kramdown:
   syntax_highlighter_opts:
     # Use existing pygments syntax highlighting css
     css_class: 'highlight'
+  math_engine: mathjax
 
 # Set the Sass partials directory, as we're using @imports
 sass:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,6 +12,8 @@
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/style.css" />
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }} - {{ site.description }}" href="{{ site.baseurl }}/feed.xml" />
 
+    <script async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+
     <!-- Created with Jekyll Now - http://github.com/barryclark/jekyll-now -->
   </head>
 


### PR DESCRIPTION
## Summary
- load MathJax in the site layout to render LaTeX equations
- configure kramdown to use MathJax for math rendering

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeed63d0ac8320b6a4c4197cbd8bfa